### PR TITLE
Use withdraw pattern in EthEscrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Truffle is an ethereum smart contract development toolchain with many awesome fe
 
 - Compile and deploy solidity contracts
 - Create js abstractions that can be used to interact with deployed contracts
-- Development environment with a simuated evm and blockchain
+- Development environment with a simulated evm and blockchain
 - Importing solidity libraries that are installed as npm modules
 - Migrations for managing deployments of smart contracts
 - EVM debugger


### PR DESCRIPTION
+ This prevents a malicious actor from using a reserve address that is
the address of a contract with a payable fallback function that always
reverts when addr.transfer() is called. When both the escrower's and
payee's funds are transferred in the same method this malicious contract
would always trap all ether in the escrow because the transaction would
always error and revert. Using the withdrawal pattern decouples the
escrower/payee withdrawals into separate methods to avoid this issue.