### PR TITLE
Add tests for construction of eth/erc20 escrows

### DIFF
--- a/test/erc20-escrow.ts
+++ b/test/erc20-escrow.ts
@@ -61,6 +61,16 @@ contract('Erc20Escrow', async (accounts) => {
         return escrow;
     }
 
+    it("Test construct Erc20 Escrow", async () => {
+        var escrowAmount = 1000;
+        var escrowTimelock = getCurrentTimeUnixEpoch();
+        var escrow = await setupERC20Escrow(escrowAmount, escrowTimelock);
+
+        assert.equal((await testToken.balanceOf(escrow.address)).toString(), escrowAmount.toString());
+        assert.equal((await escrow.escrowTimelock()).toNumber(), escrowTimelock);
+        assert.equal((await escrow.escrowState()).toNumber(), EscrowState.OPEN);
+    });
+
     it("Test cashout escrow", async () => {
         var erc20Escrow = await setupERC20Escrow(1000, getCurrentTimeUnixEpoch());
         var { eSig, pSig } = TSS.signCashout(erc20Escrow.address, 400);

--- a/test/eth-escrow.ts
+++ b/test/eth-escrow.ts
@@ -64,6 +64,18 @@ contract('EthEscrow', async (accounts) => {
         }
     }
 
+    it("Test construct Eth Escrow", async () => {
+        var escrowAmount = 1000;
+        var escrowTimelock = getCurrentTimeUnixEpoch();
+        var escrow = await setupEthEscrow(escrowAmount, escrowTimelock);
+
+        assert.equal(await web3.eth.getBalance(escrow.address), escrowAmount.toString());
+        assert.equal((await escrow.escrowTimelock()).toNumber(), escrowTimelock);
+        assert.equal((await escrow.escrowerBalance()).toString(), "0");
+        assert.equal((await escrow.payeeBalance()).toString(), "0");
+        assert.equal((await escrow.escrowState()).toNumber(), EscrowState.OPEN);
+    });
+
     it("Test cashout escrow", async () => {
         var escrow = await setupEthEscrow(1000, getCurrentTimeUnixEpoch());
         var { eSig, pSig } = TSS.signCashout(escrow.address, 400);


### PR DESCRIPTION
These just test creating the escrow without using a contract factory for a baseline to compare against.