### PR TITLE
Three stage fund

### DIFF
--- a/contracts/Escrow.sol
+++ b/contracts/Escrow.sol
@@ -294,6 +294,33 @@ contract EthEscrow is Escrow {
     }
 }
 
+contract EthEscrowTest is EthEscrow
+{
+    constructor(
+        address payable _escrowReserve,
+        address _escrowTrade,
+        address _escrowRefund,
+        address payable _payeeReserve,
+        address _payeeTrade,
+        uint _escrowAmt,
+        uint _timelock
+    ) 
+        public
+    EthEscrow(
+        _escrowReserve,
+        _escrowTrade,
+        _escrowRefund,
+        _payeeReserve,
+        _payeeTrade,
+        _escrowAmt,
+        _timelock
+    )
+    {}
+
+    function fundThisThing() external payable inState(EscrowState.UNFUNDED) {
+    }
+}
+
 
 /** 
 * @title CWC Escrow Contract backed by a ERC20 token

--- a/test/eth-escrow.ts
+++ b/test/eth-escrow.ts
@@ -3,7 +3,7 @@ import Web3 from 'web3';
 const web3 = new Web3('http://localhost:9545');
 
 // Import truffle contract abstractions
-const EthEscrow = artifacts.require("EthEscrow");
+const EthEscrow = artifacts.require("EthEscrowTest");
 
 import { EthEscrowInstance } from '../types/truffle-contracts';
 import { fail } from 'assert';
@@ -38,20 +38,26 @@ contract('EthEscrow', async (accounts) => {
             TSS.pReserve.address, TSS.pTrade.address,
             escrowAmount,
             escrowTimelock,
-            { from: mainAccount, value: 0, gas: 2000000 } //1758547 is how much truffle says
+            { from: mainAccount, value: 0, gas: 2000000 } //1808107 is how much truffle says
         );
 
         var deployReceipt = await web3.eth.getTransactionReceipt(escrow.transactionHash);
         gasMeter.TrackGasUsage("EthEscrow constructor", deployReceipt);
 
         // Seems like we are looping over this line for some reason
-        var fundTxReceipt = await web3.eth.sendTransaction({
-            from: mainAccount, 
-            to: escrow.address,
+        // var fundTxReceipt = await web3.eth.sendTransaction({
+        //     from: mainAccount, 
+        //     to: escrow.address,
+        //     value: escrowAmount,
+        //     gas: 100000 // only needs to be 2300 but ganache is dumb
+        //   });
+
+        var fundTxReceipt = await escrow.fundThisThing({
+            from: mainAccount,
             value: escrowAmount,
-            gas: 100000 // only needs to be 2300 but ganache is dumb
-          });
-        gasMeter.TrackGasUsage("EthEscrow fallback funding", fundTxReceipt);
+            gas: 100000
+            });
+        gasMeter.TrackGasUsage("EthEscrow fallback funding", fundTxReceipt.receipt);
 
         var openTx = await escrow.openEscrow({from: mainAccount, gas: 100000});
         gasMeter.TrackGasUsage("EthEscrow openEscrow", openTx.receipt);


### PR DESCRIPTION
This modification to the contract splits the escrow creation process into three steps. This allows us to deploy the escrow and the call withdraw from an exchange in order to fund the escrow. 
Procedure:
 - Deploy Escrow (~1 USD of eth as of today)
 - Fund the Escrow (User sends eth from their hot wallet or we call withdraw on an exchange)
 - Open the Escrow (since payable fallback is extremely limited in terms of gas we have to change the state of the escrow and 'open' it with a separate function call)

Will fix unit tests Soon<sup>TM</sup>