### PR TITLE
Add sighash to escrow closed event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,15 @@
         "bignumber.js": "*"
       }
     },
+    "@types/bn.js": {
+      "version": "4.11.5",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.5.tgz",
+      "integrity": "sha512-AEAZcIZga0JgVMHNtl1CprA/hXX7/wPt79AgR4XqaDt7jyj3QWYw6LPoOiznPtugDmlubUnAahMs2PFxGcQrng==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/chai": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
@@ -60,6 +69,22 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/underscore": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.9.2.tgz",
+      "integrity": "sha512-KgOKTAD+9X+qvZnB5S1+onqKc4E+PZ+T6CM/NA5ohRPLHJXb+yCJMVf8pWOnvuBuKFNUAJW8N97IA6lba6mZGg==",
+      "dev": true
+    },
+    "@types/web3": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@types/web3/-/web3-1.0.19.tgz",
+      "integrity": "sha512-fhZ9DyvDYDwHZUp5/STa9XW2re0E8GxoioYJ4pEUZ13YHpApSagixj7IAdoYH5uAK+UalGq6Ml8LYzmgRA/q+A==",
+      "dev": true,
+      "requires": {
+        "@types/bn.js": "*",
+        "@types/underscore": "*"
       }
     },
     "aes-js": {
@@ -2713,13 +2738,14 @@
       }
     },
     "truffle-typings": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/truffle-typings/-/truffle-typings-1.0.6.tgz",
-      "integrity": "sha512-oGAXGKCpf3FoxFcf000ICJf67eOFvyX3UgIgXucmECleQ4ymD+fdMkK1Qgniwi6HSBVQS6brdUiXHq8Q5A5PPA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/truffle-typings/-/truffle-typings-1.0.8.tgz",
+      "integrity": "sha512-75yFYNt0ws1TTehrGxhOqH3tutvBCAs+RG2SrhVIqQvU72kLAb4ercl32dES8yKbXBVHjzv3OXNg5gsbak+3Dg==",
       "dev": true,
       "requires": {
         "@types/chai": "^4.1.4",
-        "@types/mocha": "^5.2.5"
+        "@types/mocha": "^5.2.5",
+        "@types/web3": "^1.0.18"
       }
     },
     "ts-essentials": {
@@ -2797,9 +2823,9 @@
       }
     },
     "typechain": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/typechain/-/typechain-0.3.17.tgz",
-      "integrity": "sha512-JydKdW/xdpsp3uLz8y8WlfGX6a8/3BLAKAAmVWI4NvsJED2/BgJ5Du36OjSvlMMZDahP1AdbU+B/NsCiUqLRZg==",
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/typechain/-/typechain-0.3.19.tgz",
+      "integrity": "sha512-98TN25emSrbPraeBx+Y3ym2NxRw/kMO8qKIIqlice06f2lP6DqhJCOPtaKhytvI4v20L+Nwu57kCOyeFX9eG+g==",
       "dev": true,
       "requires": {
         "command-line-args": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "@types/bignumber.js": "^5.0.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.18",
-    "truffle-typings": "^1.0.6",
+    "truffle-typings": "^1.0.7",
     "ts-generator": "0.0.8",
     "ts-node": "^7.0.1",
-    "typechain": "^0.3.16",
+    "typechain": "^0.3.19",
     "typescript": "^3.2.2"
   },
   "scripts": {


### PR DESCRIPTION
This allows our escrow closing/recovery services on the client/hub more easily track what the sighash of the closing transaction is by directly including it in the event we emit when the escrow is closed. This make handling code much easier since we can directly go from contract log => transaction in our database that we need to update.

For `cashout` and `refund` transactions we can just directly use the sighash of the message that is being check by the contract. For `solve` and `puzzle_refund` transactions we use the the sighash of the `puzzle_posted` transaction that was previously posted. This does mean we have to add an extra state variable in the contract to store what the sighash of the puzzle_posted transaction was when it is verified.