### PR TITLE
Adds a factory deploy test to print gas usage for deployment

### DIFF
--- a/test/common.ts
+++ b/test/common.ts
@@ -4,6 +4,13 @@ import Web3 from "web3";
 
 import * as encodeUtils from "./web3js-includes/Encodepacked";
 
+// For up-to-date gas prices see: https://ethgasstation.info/
+const GAS_PRICE_GWEI = 2;
+const ETH_USD_Price = 170;
+
+console.log(`Using gas price of ${GAS_PRICE_GWEI} GWEI`);
+console.log(`Using ETH price of ${ETH_USD_Price} USD`);
+
 /**
  * Escrow state enum matching the Escrow.sol internal state machine
  */
@@ -119,11 +126,8 @@ export class GasMeter {
     }
 
     printGasCost(gasUsed: number) {
-        // For up-to-date gas prices see: https://ethgasstation.info/
-        const GAS_PRICE = web3.utils.toBN(2 * 1000 * 1000 * 1000); // 2 Gwei
-        const ETH_USD_Price = 260;
-
-        let ethPrice = web3.utils.fromWei(GAS_PRICE.mul(web3.utils.toBN(gasUsed)), "ether");
+        let gasPrice = web3.utils.toWei(web3.utils.toBN(GAS_PRICE_GWEI), "gwei");
+        let ethPrice = web3.utils.fromWei(gasPrice.mul(web3.utils.toBN(gasUsed)), "ether");
         let usdPrice = ethPrice * ETH_USD_Price;
         return `gas used ${gasUsed}, ${ethPrice} ETH, ${usdPrice} USD`;
     }

--- a/test/escrow-factory.ts
+++ b/test/escrow-factory.ts
@@ -1,0 +1,27 @@
+// Setup web3 provider to point at local development blockchain spawned by truffle develop
+import Web3 from 'web3';
+const web3 = new Web3('http://localhost:9545');
+
+// Import truffle contract abstractions
+const EscrowFactory = artifacts.require("EscrowFactory");
+
+import { GasMeter } from './common';
+
+contract('Escrow Factory', async (accounts) => {
+    var gasMeter: GasMeter;
+
+    beforeEach(async () => {
+        gasMeter = new GasMeter();
+    });
+
+    afterEach(() => {
+        gasMeter.printAggregateGasUsage(false);
+    });
+
+    it("Deploy a new contract factory", async() => {
+        var factory = await EscrowFactory.new();
+
+        var txReceipt = await web3.eth.getTransactionReceipt(factory.transactionHash);
+        gasMeter.TrackGasUsage("Create new factory", txReceipt);
+    });
+});


### PR DESCRIPTION
+ Also adjusts ETH_USD price to 170 and prints gas price/eth price being used at beginning of tests

```
 Contract: Escrow Factory
    ✓ Deploy a new contract factory (60ms)
total gas used 5384582, 0.010769164 ETH, 1.83075788 USD
```