### PR TITLE
Add force refund function to escrow library

### DIFF
--- a/test/common.ts
+++ b/test/common.ts
@@ -8,6 +8,8 @@ import BigNumber from "bignumber.js";
 const GAS_PRICE_GWEI = 2;
 const ETH_USD_PRICE = 170;
 
+export const FORCE_REFUND_TIMELOCK = 2 * 24 * 60 * 60;
+
 console.log(`Using gas price of ${GAS_PRICE_GWEI} GWEI`);
 console.log(`Using ETH price of ${ETH_USD_PRICE} USD`);
 

--- a/test/erc20-escrow.ts
+++ b/test/erc20-escrow.ts
@@ -11,7 +11,7 @@ const TestToken = artifacts.require("TestToken");
 import { EscrowFactoryInstance, EscrowLibraryInstance, Erc20EscrowInstance, TestTokenInstance } from './../types/truffle-contracts';
 import { fail } from 'assert';
 import { BigNumber } from "bignumber.js";
-import { TestSigningService, GasMeter, getCurrentTimeUnixEpoch, EscrowState, EscrowParams } from './common';
+import { TestSigningService, GasMeter, getCurrentTimeUnixEpoch, EscrowState, EscrowParams, FORCE_REFUND_TIMELOCK } from './common';
 
 contract('Erc20Escrow', async (accounts) => {
     var mainAccount = web3.utils.toChecksumAddress(accounts[0]);
@@ -134,6 +134,24 @@ contract('Erc20Escrow', async (accounts) => {
 
         assert.isTrue(new BigNumber(600).isEqualTo(await testToken.balanceOf(TSS.eReserve.address)), "final escrower reserve balance");
         assert.isTrue(new BigNumber(400).isEqualTo(await testToken.balanceOf(TSS.pReserve.address)), "final payee reserve balance");
+    });
+
+    it("Force refund fails before expiry", async () => {
+        var escrow = await setupERC20Escrow(1000, getCurrentTimeUnixEpoch());
+
+        try {
+            await escrowLibrary.forceRefund(escrow.address);
+            fail("Force refunding escrow before it has expired should fail");
+        } catch(err) {
+            assert.match(err, new RegExp("Escrow force refund timelock not reached"));
+        }
+    });
+
+    it("Force refund an escrow after it expires", async () => {
+        var escrow = await setupERC20Escrow(1000, getCurrentTimeUnixEpoch() - FORCE_REFUND_TIMELOCK);
+        await escrowLibrary.forceRefund(escrow.address);
+
+        assert.isTrue(new BigNumber(1000).isEqualTo(await testToken.balanceOf(TSS.eReserve.address)), "final escrower reserve balance");
     });
 
     it("Test postPuzzle before expiry, refundPuzzle fails, solvePuzzle works", async () => {

--- a/test/eth-escrow.ts
+++ b/test/eth-escrow.ts
@@ -10,7 +10,7 @@ const EthEscrow = artifacts.require("EthEscrow");
 import { EscrowFactoryInstance, EscrowLibraryInstance, EthEscrowInstance } from '../types/truffle-contracts';
 import { fail } from 'assert';
 import { BigNumber } from "bignumber.js";
-import { TestSigningService, GasMeter, getCurrentTimeUnixEpoch, EscrowState, EscrowParams } from './common';
+import { TestSigningService, GasMeter, getCurrentTimeUnixEpoch, EscrowState, EscrowParams, FORCE_REFUND_TIMELOCK } from './common';
 
 contract('EthEscrow', async (accounts) => {
     var mainAccount = web3.utils.toChecksumAddress(accounts[0]);
@@ -145,6 +145,24 @@ contract('EthEscrow', async (accounts) => {
 
         assert.equal(await web3.eth.getBalance(TSS.eReserve.address), "600", "final escrower reserve balance");
         assert.equal(await web3.eth.getBalance(TSS.pReserve.address), "400", "final payee reserve balance");
+    });
+
+    it("Force refund fails before expiry", async () => {
+        var escrow = await setupEthEscrow(1000, getCurrentTimeUnixEpoch());
+
+        try {
+            await escrowLibrary.forceRefund(escrow.address);
+            fail("Force refunding escrow before it has expired should fail");
+        } catch(err) {
+            assert.match(err, new RegExp("Escrow force refund timelock not reached"));
+        }
+    });
+
+    it("Force refund an escrow after it expires", async () => {
+        var escrow = await setupEthEscrow(1000, getCurrentTimeUnixEpoch() - FORCE_REFUND_TIMELOCK);
+        await escrowLibrary.forceRefund(escrow.address);
+
+        assert.equal(await web3.eth.getBalance(TSS.eReserve.address), "1000", "final escrower reserve balance");
     });
 
     it("Test postPuzzle before expiry, refundPuzzle fails, solvePuzzle works", async () => {


### PR DESCRIPTION
This allows refunding all locked funds in an escrow back to the escrower without requiring a signature meaning it will work even in the case that the escrower's keys are lost or the escrower is offline and we need to force close all escrows when rotating the factory contract.

Fixes #34 