### PR TITLE
Use sha256 as the puzzle hash function

### DIFF
--- a/contracts/Escrow.sol
+++ b/contracts/Escrow.sol
@@ -213,7 +213,7 @@ contract Escrow {
         public
         inState(EscrowState.PuzzlePosted)
     {
-        bytes32 h = keccak256(abi.encodePacked(_preimage));
+        bytes32 h = sha256(abi.encodePacked(_preimage));
         require(h == puzzle, "Invalid preimage");
 
         emit Preimage(_preimage, puzzleSighash);

--- a/test/common.ts
+++ b/test/common.ts
@@ -3,6 +3,8 @@ import { TransactionReceipt } from "web3/types";
 
 import * as encodeUtils from "./web3js-includes/Encodepacked";
 
+const crypto = require('crypto');
+
 // For up-to-date gas prices see: https://ethgasstation.info/
 const GAS_PRICE_GWEI = 2;
 const ETH_USD_PRICE = 170;
@@ -37,6 +39,13 @@ export function  generateAccount(): Account {
 
 export function getCurrentTimeUnixEpoch() {
     return Math.floor(new Date().valueOf() / 1000)
+}
+
+// preimage is a hex encoded string with '0x' prefix
+export function hashPreimage(preimage: string) : string {
+    let hasher = crypto.createHash('sha256');
+    let digest = hasher.update(preimage.slice(2), 'hex').digest('hex');
+    return `0x${digest}`;
 }
 
 interface DuoSigned { eSig: MessageSignature, pSig: MessageSignature };

--- a/test/erc20-escrow.ts
+++ b/test/erc20-escrow.ts
@@ -10,7 +10,7 @@ const TestToken = artifacts.require("TestToken");
 import { Erc20EscrowInstance, TestTokenInstance } from './../types/truffle-contracts';
 import { fail } from 'assert';
 import { BigNumber } from "bignumber.js";
-import { TestSigningService, GasMeter, getCurrentTimeUnixEpoch, EscrowState } from './common';
+import { TestSigningService, GasMeter, getCurrentTimeUnixEpoch, EscrowState, hashPreimage } from './common';
 
 contract('Erc20Escrow', async (accounts) => {
     var mainAccount = web3.utils.toChecksumAddress(accounts[0]);
@@ -138,7 +138,7 @@ contract('Erc20Escrow', async (accounts) => {
         var escrow = await setupERC20Escrow(1000, getCurrentTimeUnixEpoch());
         
         var preimage = web3.utils.keccak256("test preimage");
-        var puzzle = web3.utils.keccak256(preimage);
+        var puzzle = hashPreimage(preimage);
         var puzzleTimelock = getCurrentTimeUnixEpoch() + 24 * 60 * 60 ; // set puzzle timelock 1 day from now
         var { eSig, pSig } = TSS.signPuzzle(escrow.address, 200, 200, puzzle, puzzleTimelock);
 
@@ -172,7 +172,7 @@ contract('Erc20Escrow', async (accounts) => {
         var escrow = await setupERC20Escrow(1000, getCurrentTimeUnixEpoch());
         
         var preimage = web3.utils.keccak256("test preimage");
-        var puzzle = web3.utils.keccak256(preimage);
+        var puzzle = hashPreimage(preimage);
         var puzzleTimelock = getCurrentTimeUnixEpoch(); // set puzzle timelock to now
 
        var { eSig, pSig } = TSS.signPuzzle(escrow.address, 200, 200, puzzle, puzzleTimelock);

--- a/test/eth-escrow.ts
+++ b/test/eth-escrow.ts
@@ -9,7 +9,7 @@ const EscrowFactory = artifacts.require("EscrowFactory");
 import { EthEscrowInstance } from '../types/truffle-contracts';
 import { fail } from 'assert';
 import { BigNumber } from "bignumber.js";
-import { TestSigningService, GasMeter, getCurrentTimeUnixEpoch, EscrowState } from './common';
+import { TestSigningService, GasMeter, getCurrentTimeUnixEpoch, EscrowState, hashPreimage } from './common';
 
 contract('EthEscrow', async (accounts) => {
     var mainAccount = web3.utils.toChecksumAddress(accounts[0]);
@@ -138,7 +138,7 @@ contract('EthEscrow', async (accounts) => {
         var escrow = await setupEthEscrow(1000, getCurrentTimeUnixEpoch());
         
         var preimage = web3.utils.keccak256("test preimage");
-        var puzzle = web3.utils.keccak256(preimage);
+        var puzzle = hashPreimage(preimage);
         var puzzleTimelock = getCurrentTimeUnixEpoch() + 24 * 60 * 60 ; // set puzzle timelock 1 day from now
         var { eSig, pSig } = TSS.signPuzzle(escrow.address, 200, 200, puzzle, puzzleTimelock);
 
@@ -170,7 +170,7 @@ contract('EthEscrow', async (accounts) => {
         var escrow = await setupEthEscrow(1000, getCurrentTimeUnixEpoch());
         
         var preimage = web3.utils.keccak256("test preimage");
-        var puzzle = web3.utils.keccak256(preimage);
+        var puzzle = hashPreimage(preimage);
         var puzzleTimelock = getCurrentTimeUnixEpoch(); // set puzzle timelock to now
 
         var {eSig, pSig} = TSS.signPuzzle(escrow.address, 200, 200, puzzle, puzzleTimelock);


### PR DESCRIPTION
Use `SHA256` as the hash algorithm for the puzzle hash-lock in the contract. This makes compatibility with BTC escrows easier because they will both be using the same 'puzzle' for a given trade.