### PR TITLE
[EscrowLibrary] Guard checkFunded so it can only be called by the Escrow

### DIFF
--- a/contracts/EscrowLibrary.sol
+++ b/contracts/EscrowLibrary.sol
@@ -169,7 +169,10 @@ contract EscrowLibrary {
     */
     function checkFunded(address escrowAddress) public {
         EscrowParams storage escrowParams = escrows[escrowAddress];
+
+        require(msg.sender == escrowAddress, "Only callable by the Escrow contract");
         require(escrowParams.escrowState == EscrowState.Unfunded, "Escrow must be in state Unfunded");
+
         emit EscrowFunded(escrowAddress, Escrow(escrowAddress).balance());
     }
 


### PR DESCRIPTION
This ensures the only way to emit `EscrowFunded` events is by sending ether to the `EthEscrow`'s payable fallback function. #43 