### PR TITLE
Restrict withdraw window

### DIFF
--- a/contracts/EscrowLibrary.sol
+++ b/contracts/EscrowLibrary.sol
@@ -401,6 +401,8 @@ contract EscrowLibrary {
     function withdraw(address escrowAddress, bool escrower) public {
         EscrowParams storage escrowParams = escrows[escrowAddress];
 
+        require(escrowParams.escrowState == EscrowState.Closed, "Withdraw attempted before escrow is closed");
+
         if(escrower) {
             require(escrowParams.escrowerBalance > 0, "escrower balance is 0");
             sendEscrower(escrowAddress, escrowParams);

--- a/test/eth-escrow.ts
+++ b/test/eth-escrow.ts
@@ -256,4 +256,18 @@ contract('EthEscrow', async (accounts) => {
             assert.equal(expectedError, error.message);
         }
     });
+
+    it("Test withdraw before escrow closed", async () => {
+        var expectedError = "Returned error: VM Exception while processing transaction: revert Withdraw attempted before escrow is closed -- Reason given: Withdraw attempted before escrow is closed."
+        
+        var time = getCurrentTimeUnixEpoch()
+        var escrow = await setupEthEscrow(1000, time);
+
+        try
+        {
+            await escrowLibrary.withdraw(escrow.address, false)
+        } catch (error) {
+            assert.equal(expectedError, error.message);
+        }
+    });
 });


### PR DESCRIPTION
In this PR:
 - Withdraw cannot be called before an escrow is moved to a CLOSED state
 - Fixes: #56 